### PR TITLE
Localize timer label on quiz restart

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -55,7 +55,7 @@ restart_quiz.onclick = ()=>{
     clearInterval(counterLine); 
     startTimer(timeValue);
     startTimerLine(widthValue); 
-    timeText.textContent = "Time Left"; 
+    timeText.textContent = "Tiempo";
     next_btn.classList.remove("show"); 
 }
 


### PR DESCRIPTION
## Summary
- keep timer label in Spanish when restarting quiz

## Testing
- `npm test` *(fails: missing package.json)*
- `node` script verifying `restart_quiz.onclick()` sets timer text to Spanish


------
https://chatgpt.com/codex/tasks/task_e_68945a152f08832ba72a3d25708feca0