### PR TITLE
Use buttons for answer options

### DIFF
--- a/js/__tests__/script.test.js
+++ b/js/__tests__/script.test.js
@@ -8,10 +8,10 @@ describe('optionSelected', () => {
     const dom = new JSDOM(`
       <body>
         <div class="option_list">
-          <div class="option"><span>A</span></div>
-          <div class="option"><span>B</span></div>
-          <div class="option"><span>C</span></div>
-          <div class="option"><span>D</span></div>
+          <button class="option"><span>A</span></button>
+          <button class="option"><span>B</span></button>
+          <button class="option"><span>C</span></button>
+          <button class="option"><span>D</span></button>
         </div>
         <footer><div class="next_btn"></div></footer>
       </body>

--- a/js/script.js
+++ b/js/script.js
@@ -104,10 +104,10 @@ function showQuetions(index){
 
    
     let que_tag = '<span>'+ questions[index].numb + ". " + questions[index].question +'</span>';
-    let option_tag = '<div class="option"><span>'+ questions[index].options[0] +'</span></div>'
-    + '<div class="option"><span>'+ questions[index].options[1] +'</span></div>'
-    + '<div class="option"><span>'+ questions[index].options[2] +'</span></div>'
-    + '<div class="option"><span>'+ questions[index].options[3] +'</span></div>';
+    let option_tag = '<button class="option" type="button"><span>'+ questions[index].options[0] +'</span></button>'
+    + '<button class="option" type="button"><span>'+ questions[index].options[1] +'</span></button>'
+    + '<button class="option" type="button"><span>'+ questions[index].options[2] +'</span></button>'
+    + '<button class="option" type="button"><span>'+ questions[index].options[3] +'</span></button>';
     que_text.innerHTML = que_tag; 
     option_list.innerHTML = option_tag; 
     

--- a/style.css
+++ b/style.css
@@ -203,6 +203,8 @@ section .option_list .option{
     display: flex;
     align-items: center;
     justify-content: space-between;
+    width: 100%;
+    outline: none;
 }
 
 section .option_list .option:last-child{


### PR DESCRIPTION
## Summary
- render question choices as `<button class="option">` elements
- tweak option styles for buttons and expand tests to use buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68946c0b7d58832b8b476fdf577453a9